### PR TITLE
Add retired question flag for soft-removing questions

### DIFF
--- a/mobile-app/src/core/Game.tsx
+++ b/mobile-app/src/core/Game.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { type GameConfig, type Question, type Feedback } from './types';
-import { seededShuffle, selectBalancedSubset, isCorrect } from './gameLogic';
+import { seededShuffle, selectBalancedSubset, isCorrect, activeQuestions } from './gameLogic';
 import { usePlayerStore } from '../store/playerStore';
 import { useAuthStore } from '../store/authStore';
 import { submitScore } from '../services/scoreService';
@@ -106,10 +106,13 @@ export default function Game({
     setElapsed(0);
     const seed = Math.floor(Math.random() * 0x100000000);
     gameSeedRef.current = seed;
+    // For new games, exclude retired questions. Existing challenges/tournaments
+    // must use the full pool so the stored seed produces the same deck.
+    const pool = challengeId ? config.questions : activeQuestions(config.questions);
     if (config.questionCount) {
-      setDeck(selectBalancedSubset(config.questions, config.questionCount, seed));
+      setDeck(selectBalancedSubset(pool, config.questionCount, seed));
     } else {
-      setDeck(seededShuffle(config.questions, seed));
+      setDeck(seededShuffle(pool, seed));
     }
     setCurrentIndex(0);
     setMissed([]);
@@ -121,7 +124,7 @@ export default function Game({
       elapsedRef.current += 1;
       setElapsed(elapsedRef.current);
     }, 1000);
-  }, [config.questions, config.questionCount]);
+  }, [config.questions, config.questionCount, challengeId]);
 
   const advance = useCallback((wasCorrect: boolean, question: Question) => {
     if (!wasCorrect) setMissed(prev => [...prev, question]);

--- a/mobile-app/src/core/__tests__/gameLogic.test.ts
+++ b/mobile-app/src/core/__tests__/gameLogic.test.ts
@@ -3,6 +3,7 @@ import {
   seededShuffle,
   selectBalancedSubset,
   isCorrect,
+  activeQuestions,
 } from '../gameLogic';
 import { type Question } from '../types';
 
@@ -131,6 +132,41 @@ describe('selectBalancedSubset', () => {
     const result = selectBalancedSubset(pool, 10, 42);
     const ids = result.map(q => q.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('activeQuestions', () => {
+  it('filters out retired questions', () => {
+    const questions = [
+      makeQuestion('a', [], 'easy', 1),
+      { ...makeQuestion('b', [], 'easy', 2), retired: true },
+      makeQuestion('c', [], 'easy', 3),
+    ];
+    const result = activeQuestions(questions);
+    expect(result).toHaveLength(2);
+    expect(result.map(q => q.id)).toEqual([1, 3]);
+  });
+
+  it('returns all questions when none are retired', () => {
+    const questions = [
+      makeQuestion('a', [], 'easy', 1),
+      makeQuestion('b', [], 'medium', 2),
+    ];
+    expect(activeQuestions(questions)).toHaveLength(2);
+  });
+
+  it('returns empty array when all are retired', () => {
+    const questions = [
+      { ...makeQuestion('a', [], 'easy', 1), retired: true },
+      { ...makeQuestion('b', [], 'easy', 2), retired: true },
+    ];
+    expect(activeQuestions(questions)).toHaveLength(0);
+  });
+
+  it('treats undefined retired as active', () => {
+    const q = makeQuestion('a', [], 'easy', 1);
+    expect(q.retired).toBeUndefined();
+    expect(activeQuestions([q])).toHaveLength(1);
   });
 });
 

--- a/mobile-app/src/core/gameLogic.ts
+++ b/mobile-app/src/core/gameLogic.ts
@@ -81,6 +81,11 @@ export function selectBalancedSubset(
   return seededShuffle(picked, seed + 13);
 }
 
+/** Filter out retired questions — use only for new games, not seeded replays. */
+export function activeQuestions(questions: Question[]): Question[] {
+  return questions.filter(q => !q.retired);
+}
+
 export function isCorrect(input: string, question: Question): boolean {
   const n = normalize(input);
   if (!n) return false;

--- a/mobile-app/src/core/types.ts
+++ b/mobile-app/src/core/types.ts
@@ -14,6 +14,7 @@ export interface Question {
   difficulty: Difficulty;
   aliases: string[];
   hint?: string;
+  retired?: boolean;
 }
 
 export interface Theme {


### PR DESCRIPTION
Adds a `retired?: boolean` field to the `Question` type. Questions marked as retired are excluded from new games but still included when joining existing challenges/tournaments, preserving seeded determinism for in-progress games. Includes an `activeQuestions()` filter utility and 4 new tests.