### PR TITLE
Remove Supabase error console.error calls in clock-app

### DIFF
--- a/clock-app/src/services/playerService.ts
+++ b/clock-app/src/services/playerService.ts
@@ -1,10 +1,9 @@
 import { supabase } from '../lib/supabase';
 
 export async function upsertPlayer(id: string, nickname: string): Promise<void> {
-  const { error } = await supabase
+  await supabase
     .from('players')
     .upsert({ id, nickname }, { onConflict: 'id' });
-  if (error) console.error('[db] upsertPlayer:', error.message);
 }
 
 export async function searchPlayersByNickname(query: string): Promise<{ id: string; nickname: string }[]> {
@@ -14,7 +13,6 @@ export async function searchPlayersByNickname(query: string): Promise<{ id: stri
     .ilike('nickname', `%${query}%`)
     .limit(10);
   if (error) {
-    console.error('[db] searchPlayersByNickname:', error.message);
     return [];
   }
   return data ?? [];

--- a/clock-app/src/services/scoreService.ts
+++ b/clock-app/src/services/scoreService.ts
@@ -19,7 +19,6 @@ export async function submitScore(params: {
     .select('id')
     .single();
   if (error) {
-    console.error('[db] submitScore:', error.message);
     return null;
   }
   return data?.id ?? null;

--- a/clock-app/src/store/authStore.ts
+++ b/clock-app/src/store/authStore.ts
@@ -20,7 +20,6 @@ export const useAuthStore = create<AuthStore>((set) => ({
 
     const { data, error } = await supabase.auth.signInAnonymously();
     if (error) {
-      console.error('[auth] Anonymous sign-in failed:', error.message);
       set({ isReady: true });
       return;
     }


### PR DESCRIPTION
## Summary
- Drops four noisy \`console.error\` calls copied over from \`mobile-app/\`: in \`authStore.init()\`, \`upsertPlayer\`, \`searchPlayersByNickname\`, and \`submitScore\`.
- Error-path control flow (early return with \`isReady: true\`, \`return []\`, \`return null\`) is preserved — only the log line is removed.

## Test plan
- [x] \`yarn lint\` — no new warnings introduced (pre-existing unused-var warnings in \`MultipleChoice.tsx\` / \`StarDisplay.tsx\` are unrelated)
- [x] \`yarn test\` — no change (clock-app currently has no tests; tests land in a later PR)
- [ ] Manual smoke: \`yarn start\`, play a level, confirm no console spam