### PR TITLE
Add test suite for clock-app

### DIFF
--- a/clock-app/src/components/__tests__/AnalogClock.test.tsx
+++ b/clock-app/src/components/__tests__/AnalogClock.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import AnalogClock from '../AnalogClock';
+
+describe('AnalogClock', () => {
+  it('renders without crashing for 3:00', () => {
+    const { UNSAFE_getByType } = render(<AnalogClock hour={3} minute={0} />);
+    // Just assert that an Svg is present via the mock
+    expect(UNSAFE_getByType).toBeTruthy();
+  });
+
+  it('renders more lines when showMinuteMarks is true (ticks + 2 hands)', () => {
+    const withMarks = render(<AnalogClock hour={6} minute={30} />);
+    const withoutMarks = render(<AnalogClock hour={6} minute={30} showMinuteMarks={false} />);
+    const withCount = withMarks.UNSAFE_getAllByProps({ testID: 'Line' }).length;
+    const withoutCount = withoutMarks.UNSAFE_getAllByProps({ testID: 'Line' }).length;
+    // With ticks should render 60 extra lines than the 2-hand baseline.
+    expect(withCount - withoutCount).toBeGreaterThanOrEqual(60);
+  });
+
+  it('renders numbers 1 through 12', () => {
+    const { getByText } = render(<AnalogClock hour={3} minute={0} />);
+    for (let n = 1; n <= 12; n++) {
+      expect(getByText(String(n))).toBeTruthy();
+    }
+  });
+
+  it('accepts a custom size prop', () => {
+    const { UNSAFE_getAllByProps } = render(<AnalogClock hour={3} minute={0} size={400} />);
+    const svgs = UNSAFE_getAllByProps({ testID: 'Svg' });
+    expect(svgs[0].props.width).toBe(400);
+    expect(svgs[0].props.height).toBe(400);
+  });
+});

--- a/clock-app/src/components/__tests__/DigitalClock.test.tsx
+++ b/clock-app/src/components/__tests__/DigitalClock.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import DigitalClock from '../DigitalClock';
+
+describe('DigitalClock', () => {
+  it('renders 24-hour mode with zero-padded hour', () => {
+    const { getByText } = render(<DigitalClock hour={3} minute={5} mode="digital24" />);
+    expect(getByText('03:05')).toBeTruthy();
+  });
+
+  it('renders 24-hour mode at midnight', () => {
+    const { getByText } = render(<DigitalClock hour={0} minute={0} mode="digital24" />);
+    expect(getByText('00:00')).toBeTruthy();
+  });
+
+  it('renders 24-hour mode at 23:59', () => {
+    const { getByText } = render(<DigitalClock hour={23} minute={59} mode="digital24" />);
+    expect(getByText('23:59')).toBeTruthy();
+  });
+
+  it('renders 12-hour mode with AM suffix before noon', () => {
+    const { getByText } = render(<DigitalClock hour={3} minute={5} mode="digital12" />);
+    expect(getByText('3:05')).toBeTruthy();
+    expect(getByText('AM')).toBeTruthy();
+  });
+
+  it('renders 12-hour mode with PM suffix after noon', () => {
+    const { getByText } = render(<DigitalClock hour={15} minute={45} mode="digital12" />);
+    expect(getByText('3:45')).toBeTruthy();
+    expect(getByText('PM')).toBeTruthy();
+  });
+
+  it('renders 12 AM for midnight in 12-hour mode', () => {
+    const { getByText } = render(<DigitalClock hour={0} minute={0} mode="digital12" />);
+    expect(getByText('12:00')).toBeTruthy();
+    expect(getByText('AM')).toBeTruthy();
+  });
+
+  it('renders 12 PM for noon in 12-hour mode', () => {
+    const { getByText } = render(<DigitalClock hour={12} minute={0} mode="digital12" />);
+    expect(getByText('12:00')).toBeTruthy();
+    expect(getByText('PM')).toBeTruthy();
+  });
+});

--- a/clock-app/src/components/__tests__/FeedbackBanner.test.tsx
+++ b/clock-app/src/components/__tests__/FeedbackBanner.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import FeedbackBanner from '../FeedbackBanner';
+
+describe('FeedbackBanner', () => {
+  it('renders nothing when feedback is null', () => {
+    const { toJSON } = render(<FeedbackBanner feedback={null} correctAnswer="3:00" />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders "Correct!" on correct feedback', () => {
+    const { getByText } = render(<FeedbackBanner feedback="correct" correctAnswer="3:00" />);
+    expect(getByText(/Correct!/)).toBeTruthy();
+  });
+
+  it('renders the correct answer on wrong feedback', () => {
+    const { getByText } = render(<FeedbackBanner feedback="wrong" correctAnswer="3:00" />);
+    expect(getByText('3:00')).toBeTruthy();
+    expect(getByText(/The answer was/)).toBeTruthy();
+  });
+});

--- a/clock-app/src/components/__tests__/LevelCard.test.tsx
+++ b/clock-app/src/components/__tests__/LevelCard.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import LevelCard from '../LevelCard';
+
+describe('LevelCard', () => {
+  it('renders the level title and multiple-choice label', () => {
+    const { getByText } = render(
+      <LevelCard levelNumber={3} inputMode="multipleChoice" bestStars={0} onPress={jest.fn()} />,
+    );
+    expect(getByText('Level 3')).toBeTruthy();
+    expect(getByText('Multiple Choice')).toBeTruthy();
+  });
+
+  it('shows the free-text mode label when inputMode is freeText', () => {
+    const { getByText } = render(
+      <LevelCard levelNumber={3} inputMode="freeText" bestStars={0} onPress={jest.fn()} />,
+    );
+    expect(getByText('Type the Time')).toBeTruthy();
+  });
+
+  it('shows the level number badge for non-bonus levels', () => {
+    const { getByText } = render(
+      <LevelCard levelNumber={4} inputMode="multipleChoice" bestStars={0} onPress={jest.fn()} />,
+    );
+    expect(getByText('4')).toBeTruthy();
+  });
+
+  it('shows the infinity badge for bonus levels', () => {
+    const { getByText } = render(
+      <LevelCard levelNumber={9} inputMode="freeText" bestStars={0} onPress={jest.fn()} isBonus />,
+    );
+    expect(getByText('\u{267E}')).toBeTruthy();
+  });
+
+  it('calls onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <LevelCard levelNumber={1} inputMode="multipleChoice" bestStars={2} onPress={onPress} />,
+    );
+    fireEvent.press(getByText('Level 1'));
+    expect(onPress).toHaveBeenCalled();
+  });
+});

--- a/clock-app/src/components/__tests__/MultipleChoice.test.tsx
+++ b/clock-app/src/components/__tests__/MultipleChoice.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import MultipleChoice from '../MultipleChoice';
+
+describe('MultipleChoice', () => {
+  const choices = ['1:00', '2:00', '3:00', '4:00'];
+
+  it('renders every choice', () => {
+    const { getByText } = render(
+      <MultipleChoice
+        choices={choices}
+        correctAnswer="3:00"
+        feedback={null}
+        onSelect={jest.fn()}
+      />,
+    );
+    for (const c of choices) {
+      expect(getByText(c)).toBeTruthy();
+    }
+  });
+
+  it('calls onSelect when a choice is pressed', () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <MultipleChoice
+        choices={choices}
+        correctAnswer="3:00"
+        feedback={null}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.press(getByText('2:00'));
+    expect(onSelect).toHaveBeenCalledWith('2:00');
+  });
+
+  it('does not call onSelect while feedback is shown', () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <MultipleChoice
+        choices={choices}
+        correctAnswer="3:00"
+        feedback="wrong"
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.press(getByText('2:00'));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/clock-app/src/components/__tests__/ProgressDots.test.tsx
+++ b/clock-app/src/components/__tests__/ProgressDots.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { View } from 'react-native';
+import ProgressDots from '../ProgressDots';
+
+describe('ProgressDots', () => {
+  it('renders `total` dots', () => {
+    const { UNSAFE_queryAllByType } = render(<ProgressDots current={1} total={5} />);
+    // outer View + N dots -> expect 1 + 5
+    const views = UNSAFE_queryAllByType(View);
+    expect(views.length).toBe(6);
+  });
+
+  it('renders only a single root view when total is 0', () => {
+    const { UNSAFE_queryAllByType } = render(<ProgressDots current={0} total={0} />);
+    const views = UNSAFE_queryAllByType(View);
+    expect(views.length).toBe(1);
+  });
+
+  it('renders one dot per total, regardless of current', () => {
+    const { UNSAFE_queryAllByType } = render(<ProgressDots current={10} total={3} />);
+    const views = UNSAFE_queryAllByType(View);
+    expect(views.length).toBe(4);
+  });
+});

--- a/clock-app/src/components/__tests__/StarDisplay.test.tsx
+++ b/clock-app/src/components/__tests__/StarDisplay.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import StarDisplay from '../StarDisplay';
+
+const FILLED = '\u2B50';
+const EMPTY = '\u2606';
+
+describe('StarDisplay', () => {
+  it('renders 3 empty stars for 0 rating', () => {
+    const { queryAllByText } = render(<StarDisplay stars={0} />);
+    expect(queryAllByText(EMPTY).length).toBe(3);
+    expect(queryAllByText(FILLED).length).toBe(0);
+  });
+
+  it('renders 1 filled and 2 empty for 1 star', () => {
+    const { queryAllByText } = render(<StarDisplay stars={1} />);
+    expect(queryAllByText(FILLED).length).toBe(1);
+    expect(queryAllByText(EMPTY).length).toBe(2);
+  });
+
+  it('renders 2 filled and 1 empty for 2 stars', () => {
+    const { queryAllByText } = render(<StarDisplay stars={2} />);
+    expect(queryAllByText(FILLED).length).toBe(2);
+    expect(queryAllByText(EMPTY).length).toBe(1);
+  });
+
+  it('renders 3 filled stars for 3', () => {
+    const { queryAllByText } = render(<StarDisplay stars={3} />);
+    expect(queryAllByText(FILLED).length).toBe(3);
+    expect(queryAllByText(EMPTY).length).toBe(0);
+  });
+
+  it('applies the given font size', () => {
+    const { getAllByText } = render(<StarDisplay stars={3} size={80} />);
+    const star = getAllByText(FILLED)[0];
+    const flat = Array.isArray(star.props.style)
+      ? star.props.style.flat().find((s: { fontSize?: number }) => s?.fontSize)
+      : star.props.style;
+    expect(flat.fontSize).toBe(80);
+  });
+});

--- a/clock-app/src/components/__tests__/TimeInput.test.tsx
+++ b/clock-app/src/components/__tests__/TimeInput.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import TimeInput from '../TimeInput';
+
+describe('TimeInput', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    act(() => { jest.runOnlyPendingTimers(); });
+    jest.useRealTimers();
+  });
+
+  it('renders Check and Skip buttons', () => {
+    const { getByText } = render(
+      <TimeInput feedback={null} onSubmit={jest.fn()} onSkip={jest.fn()} />,
+    );
+    expect(getByText('Check')).toBeTruthy();
+    expect(getByText('Skip')).toBeTruthy();
+  });
+
+  it('calls onSubmit with the typed value when Check pressed', () => {
+    const onSubmit = jest.fn();
+    const { getByText, getByPlaceholderText } = render(
+      <TimeInput feedback={null} onSubmit={onSubmit} onSkip={jest.fn()} />,
+    );
+    fireEvent.changeText(getByPlaceholderText(/Type the time/i), '3:00');
+    fireEvent.press(getByText('Check'));
+    expect(onSubmit).toHaveBeenCalledWith('3:00');
+  });
+
+  it('calls onSkip when Skip pressed', () => {
+    const onSkip = jest.fn();
+    const { getByText } = render(
+      <TimeInput feedback={null} onSubmit={jest.fn()} onSkip={onSkip} />,
+    );
+    fireEvent.press(getByText('Skip'));
+    expect(onSkip).toHaveBeenCalled();
+  });
+
+  it('does not submit empty input', () => {
+    const onSubmit = jest.fn();
+    const { getByText } = render(
+      <TimeInput feedback={null} onSubmit={onSubmit} onSkip={jest.fn()} />,
+    );
+    fireEvent.press(getByText('Check'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not submit while feedback is shown', () => {
+    const onSubmit = jest.fn();
+    const { getByText, getByPlaceholderText } = render(
+      <TimeInput feedback="correct" onSubmit={onSubmit} onSkip={jest.fn()} />,
+    );
+    fireEvent.changeText(getByPlaceholderText(/Type the time/i), '3:00');
+    fireEvent.press(getByText('Check'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('auto-inserts a colon when user types 3+ bare digits', () => {
+    const { getByPlaceholderText } = render(
+      <TimeInput feedback={null} onSubmit={jest.fn()} onSkip={jest.fn()} />,
+    );
+    const input = getByPlaceholderText(/Type the time/i);
+    fireEvent.changeText(input, '300');
+    expect(input.props.value).toBe('3:00');
+  });
+
+  it('filters out disallowed characters', () => {
+    const { getByPlaceholderText } = render(
+      <TimeInput feedback={null} onSubmit={jest.fn()} onSkip={jest.fn()} />,
+    );
+    const input = getByPlaceholderText(/Type the time/i);
+    fireEvent.changeText(input, '3x!');
+    expect(input.props.value).toBe('3');
+  });
+});

--- a/clock-app/src/continents/__tests__/registry.test.ts
+++ b/clock-app/src/continents/__tests__/registry.test.ts
@@ -1,0 +1,43 @@
+import { getContinent, getAllContinents } from '../registry';
+
+describe('continents registry', () => {
+  it('returns all three continents from getAllContinents', () => {
+    const all = getAllContinents();
+    expect(all.map((c) => c.id)).toEqual(['analogLand', 'digital24', 'digital12']);
+  });
+
+  it('getContinent returns the continent with matching id', () => {
+    expect(getContinent('analogLand').id).toBe('analogLand');
+    expect(getContinent('digital24').id).toBe('digital24');
+    expect(getContinent('digital12').id).toBe('digital12');
+  });
+
+  it('every continent has a non-empty paths list', () => {
+    for (const c of getAllContinents()) {
+      expect(c.paths.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every path has at least one level', () => {
+    for (const c of getAllContinents()) {
+      for (const p of c.paths) {
+        expect(p.levels.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('every level has a valid generator config and input mode', () => {
+    const validTypes = new Set([
+      'wholeHours', 'halfHours', 'quarterHours', 'fiveMinutes', 'anyMinute', 'mixedReview',
+    ]);
+    for (const c of getAllContinents()) {
+      for (const p of c.paths) {
+        for (const l of p.levels) {
+          expect(validTypes.has(l.generator.type)).toBe(true);
+          expect(['multipleChoice', 'freeText']).toContain(l.inputMode);
+          expect(l.questionCount).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+});

--- a/clock-app/src/core/__tests__/LevelEngine.test.tsx
+++ b/clock-app/src/core/__tests__/LevelEngine.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import LevelEngine from '../LevelEngine';
+import { type LevelDef, type ClockQuestion, type Feedback } from '../types';
+
+jest.useFakeTimers();
+
+jest.mock('../clockLogic', () => ({
+  generateLevelQuestions: jest.fn(),
+  isTimeCorrect: jest.fn((answer: string, q: { correctAnswer: string }) => answer === q.correctAnswer),
+}));
+
+jest.mock('../../lib/haptics', () => ({
+  hapticCorrect: jest.fn(),
+  hapticWrong: jest.fn(),
+  hapticSuccess: jest.fn(),
+}));
+
+jest.mock('../../lib/sounds', () => ({
+  playCorrect: jest.fn(),
+  playWrong: jest.fn(),
+}));
+
+import { generateLevelQuestions } from '../clockLogic';
+
+const mockedGenerate = generateLevelQuestions as jest.MockedFunction<typeof generateLevelQuestions>;
+
+const makeQuestion = (id: string, correct: string): ClockQuestion => ({
+  id,
+  hour: 3,
+  minute: 0,
+  displayMode: 'analog',
+  correctAnswer: correct,
+  aliases: [],
+});
+
+const levelDef: LevelDef = {
+  levelNumber: 1,
+  questionCount: 3,
+  inputMode: 'freeText',
+  generator: { type: 'wholeHours', displayMode: 'analog' },
+};
+
+interface RenderedProps {
+  question: ClockQuestion;
+  onAnswer: (a: string) => void;
+  onSkip: () => void;
+  feedback: Feedback;
+  current: number;
+  total: number;
+  score: number;
+}
+
+function renderEngine(onFinish: jest.Mock) {
+  const lastProps: { current: RenderedProps | null } = { current: null };
+  const utils = render(
+    <LevelEngine
+      levelDef={levelDef}
+      onFinish={onFinish}
+      renderPlaying={(props) => {
+        lastProps.current = props;
+        return (
+          <>
+            <Text testID="correct-answer">{props.question.correctAnswer}</Text>
+            <Text testID="score">{props.score}</Text>
+            <Text testID="current">{props.current}</Text>
+            <Text testID="feedback">{props.feedback ?? 'none'}</Text>
+            <TouchableOpacity testID="submit" onPress={() => props.onAnswer(props.question.correctAnswer)}>
+              <Text>Correct</Text>
+            </TouchableOpacity>
+            <TouchableOpacity testID="submit-wrong" onPress={() => props.onAnswer('WRONG')}>
+              <Text>Wrong</Text>
+            </TouchableOpacity>
+            <TouchableOpacity testID="skip" onPress={props.onSkip}>
+              <Text>Skip</Text>
+            </TouchableOpacity>
+          </>
+        );
+      }}
+    />
+  );
+  return { ...utils, lastProps };
+}
+
+describe('LevelEngine', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGenerate.mockReturnValue([
+      makeQuestion('q1', '3:00'),
+      makeQuestion('q2', '4:00'),
+      makeQuestion('q3', '5:00'),
+    ]);
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+  });
+
+  it('renders nothing until deck is generated', () => {
+    mockedGenerate.mockReturnValue([]);
+    const onFinish = jest.fn();
+    const { queryByTestId } = renderEngine(onFinish);
+    expect(queryByTestId('score')).toBeNull();
+  });
+
+  it('renders the first question on mount', () => {
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    expect(getByTestId('correct-answer').props.children).toBe('3:00');
+    expect(getByTestId('current').props.children).toBe(1);
+    expect(getByTestId('score').props.children).toBe(0);
+  });
+
+  it('increments score on correct answer', () => {
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    fireEvent.press(getByTestId('submit'));
+    expect(getByTestId('score').props.children).toBe(1);
+    expect(getByTestId('feedback').props.children).toBe('correct');
+  });
+
+  it('shows wrong feedback on incorrect answer and leaves score unchanged', () => {
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    fireEvent.press(getByTestId('submit-wrong'));
+    expect(getByTestId('feedback').props.children).toBe('wrong');
+    expect(getByTestId('score').props.children).toBe(0);
+  });
+
+  it('advances to the next question after a correct answer', () => {
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    fireEvent.press(getByTestId('submit'));
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(getByTestId('correct-answer').props.children).toBe('4:00');
+    expect(getByTestId('current').props.children).toBe(2);
+    expect(getByTestId('feedback').props.children).toBe('none');
+  });
+
+  it('uses a longer delay after a wrong answer (2s)', () => {
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    fireEvent.press(getByTestId('submit-wrong'));
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(getByTestId('current').props.children).toBe(1);
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(getByTestId('current').props.children).toBe(2);
+  });
+
+  it('treats skip as wrong and advances', () => {
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    fireEvent.press(getByTestId('skip'));
+    expect(getByTestId('feedback').props.children).toBe('wrong');
+    expect(getByTestId('score').props.children).toBe(0);
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(getByTestId('current').props.children).toBe(2);
+  });
+
+  it('ignores presses while feedback is shown', () => {
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    fireEvent.press(getByTestId('submit'));
+    fireEvent.press(getByTestId('submit'));
+    expect(getByTestId('score').props.children).toBe(1);
+  });
+
+  it('calls onFinish with final score and star rating after the last question', () => {
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    // Answer all 3 correctly
+    fireEvent.press(getByTestId('submit'));
+    act(() => { jest.advanceTimersByTime(1000); });
+    fireEvent.press(getByTestId('submit'));
+    act(() => { jest.advanceTimersByTime(1000); });
+    fireEvent.press(getByTestId('submit'));
+    act(() => { jest.advanceTimersByTime(1000); });
+
+    expect(onFinish).toHaveBeenCalledWith(3, 3, 3);
+  });
+
+  it('reports 0 stars when no questions answered correctly', () => {
+    mockedGenerate.mockReturnValue([
+      makeQuestion('q1', '3:00'),
+      makeQuestion('q2', '4:00'),
+      makeQuestion('q3', '5:00'),
+      makeQuestion('q4', '6:00'),
+      makeQuestion('q5', '7:00'),
+    ]);
+    const onFinish = jest.fn();
+    const { getByTestId } = renderEngine(onFinish);
+    for (let i = 0; i < 5; i++) {
+      fireEvent.press(getByTestId('submit-wrong'));
+      act(() => { jest.advanceTimersByTime(2000); });
+    }
+    expect(onFinish).toHaveBeenCalledWith(0, 5, 0);
+  });
+});

--- a/clock-app/src/core/__tests__/bonusGenerator.test.ts
+++ b/clock-app/src/core/__tests__/bonusGenerator.test.ts
@@ -1,0 +1,63 @@
+import { generateBonusLevel, generateBonusLevels } from '../bonusGenerator';
+import { type Path, type LevelDef } from '../types';
+
+const makeLevel = (levelNumber: number): LevelDef => ({
+  levelNumber,
+  questionCount: 5,
+  inputMode: 'multipleChoice',
+  generator: { type: 'wholeHours', displayMode: 'analog' },
+});
+
+const makePath = (lastLevel: number): Path => ({
+  id: 'test-path',
+  continentId: 'analogLand',
+  title: 'Test Path',
+  description: 'A path for tests',
+  emoji: '\u{1F570}',
+  bossEmoji: '\u{1F989}',
+  levels: Array.from({ length: lastLevel }, (_, i) => makeLevel(i + 1)),
+});
+
+describe('generateBonusLevel', () => {
+  it('uses the given level number', () => {
+    const path = makePath(5);
+    const bonus = generateBonusLevel(path, 6);
+    expect(bonus.levelNumber).toBe(6);
+  });
+
+  it('uses freeText input mode', () => {
+    const path = makePath(5);
+    expect(generateBonusLevel(path, 6).inputMode).toBe('freeText');
+  });
+
+  it('inherits the generator config from the last static level', () => {
+    const path = makePath(5);
+    const bonus = generateBonusLevel(path, 6);
+    expect(bonus.generator).toEqual(path.levels[path.levels.length - 1].generator);
+  });
+
+  it('scales question count with distance past the last static level', () => {
+    const path = makePath(5);
+    expect(generateBonusLevel(path, 6).questionCount).toBe(12);
+    expect(generateBonusLevel(path, 7).questionCount).toBe(14);
+    expect(generateBonusLevel(path, 10).questionCount).toBe(20);
+  });
+});
+
+describe('generateBonusLevels', () => {
+  it('generates the requested number of bonus levels', () => {
+    const path = makePath(5);
+    expect(generateBonusLevels(path, 5, 3)).toHaveLength(3);
+  });
+
+  it('numbers them sequentially after the last static level', () => {
+    const path = makePath(5);
+    const bonuses = generateBonusLevels(path, 5, 3);
+    expect(bonuses.map((b) => b.levelNumber)).toEqual([6, 7, 8]);
+  });
+
+  it('returns empty array when count is 0', () => {
+    const path = makePath(5);
+    expect(generateBonusLevels(path, 5, 0)).toEqual([]);
+  });
+});

--- a/clock-app/src/core/__tests__/clockLogic.test.ts
+++ b/clock-app/src/core/__tests__/clockLogic.test.ts
@@ -1,0 +1,247 @@
+import {
+  toHour12,
+  formatTimeAnswer,
+  normalizeTimeInput,
+  isTimeCorrect,
+  generateLevelQuestions,
+} from '../clockLogic';
+import { type ClockQuestion, type QuestionGeneratorConfig } from '../types';
+
+const makeQuestion = (
+  correctAnswer: string,
+  aliases: string[] = [],
+  displayMode: ClockQuestion['displayMode'] = 'analog',
+): ClockQuestion => ({
+  id: 'q-1',
+  hour: 3,
+  minute: 0,
+  displayMode,
+  correctAnswer,
+  aliases,
+});
+
+describe('toHour12', () => {
+  it('returns 12 AM for hour 0', () => {
+    expect(toHour12(0)).toEqual({ h12: 12, period: 'AM' });
+  });
+
+  it('returns 1-11 AM for morning hours', () => {
+    expect(toHour12(1)).toEqual({ h12: 1, period: 'AM' });
+    expect(toHour12(11)).toEqual({ h12: 11, period: 'AM' });
+  });
+
+  it('returns 12 PM for hour 12', () => {
+    expect(toHour12(12)).toEqual({ h12: 12, period: 'PM' });
+  });
+
+  it('returns 1-11 PM for afternoon hours', () => {
+    expect(toHour12(13)).toEqual({ h12: 1, period: 'PM' });
+    expect(toHour12(23)).toEqual({ h12: 11, period: 'PM' });
+  });
+
+  it('handles every hour in 0-23', () => {
+    for (let h = 0; h < 24; h++) {
+      const { h12, period } = toHour12(h);
+      expect(h12).toBeGreaterThanOrEqual(1);
+      expect(h12).toBeLessThanOrEqual(12);
+      expect(['AM', 'PM']).toContain(period);
+    }
+  });
+});
+
+describe('formatTimeAnswer', () => {
+  it('formats analog display without leading zero on hour', () => {
+    expect(formatTimeAnswer(3, 0, 'analog')).toBe('3:00');
+    expect(formatTimeAnswer(10, 45, 'analog')).toBe('10:45');
+  });
+
+  it('pads minutes with leading zero', () => {
+    expect(formatTimeAnswer(3, 5, 'analog')).toBe('3:05');
+  });
+
+  it('formats digital24 with zero-padded hour', () => {
+    expect(formatTimeAnswer(3, 0, 'digital24')).toBe('03:00');
+    expect(formatTimeAnswer(0, 0, 'digital24')).toBe('00:00');
+    expect(formatTimeAnswer(23, 59, 'digital24')).toBe('23:59');
+  });
+
+  it('formats digital12 with AM/PM suffix', () => {
+    expect(formatTimeAnswer(0, 30, 'digital12')).toBe('12:30 AM');
+    expect(formatTimeAnswer(12, 0, 'digital12')).toBe('12:00 PM');
+    expect(formatTimeAnswer(15, 45, 'digital12')).toBe('3:45 PM');
+  });
+});
+
+describe('normalizeTimeInput', () => {
+  it('trims whitespace', () => {
+    expect(normalizeTimeInput('  3:00  ')).toBe('3:00');
+  });
+
+  it('converts dots to colons', () => {
+    expect(normalizeTimeInput('3.00')).toBe('3:00');
+    expect(normalizeTimeInput('12.45')).toBe('12:45');
+  });
+
+  it('inserts colon into 3-digit input', () => {
+    expect(normalizeTimeInput('300')).toBe('3:00');
+    expect(normalizeTimeInput('945')).toBe('9:45');
+  });
+
+  it('inserts colon into 4-digit input', () => {
+    expect(normalizeTimeInput('1200')).toBe('12:00');
+    expect(normalizeTimeInput('0315')).toBe('03:15');
+  });
+
+  it('leaves colon-separated input alone', () => {
+    expect(normalizeTimeInput('3:00')).toBe('3:00');
+  });
+
+  it('leaves non-numeric-only input alone', () => {
+    expect(normalizeTimeInput('3:00 PM')).toBe('3:00 PM');
+  });
+});
+
+describe('isTimeCorrect', () => {
+  it('matches the correctAnswer exactly', () => {
+    const q = makeQuestion('3:00', ['03:00', '3.00']);
+    expect(isTimeCorrect('3:00', q)).toBe(true);
+  });
+
+  it('matches aliases', () => {
+    const q = makeQuestion('3:00', ['03:00', '3.00']);
+    expect(isTimeCorrect('03:00', q)).toBe(true);
+    expect(isTimeCorrect('3.00', q)).toBe(true);
+  });
+
+  it('is case-insensitive for AM/PM', () => {
+    const q = makeQuestion('3:00 PM', ['3:00 pm', '3:00pm'], 'digital12');
+    expect(isTimeCorrect('3:00 PM', q)).toBe(true);
+    expect(isTimeCorrect('3:00 pm', q)).toBe(true);
+  });
+
+  it('trims whitespace before matching', () => {
+    const q = makeQuestion('3:00');
+    expect(isTimeCorrect('  3:00  ', q)).toBe(true);
+  });
+
+  it('normalises dot to colon before matching', () => {
+    const q = makeQuestion('3:00');
+    expect(isTimeCorrect('3.00', q)).toBe(true);
+  });
+
+  it('normalises missing colon before matching', () => {
+    const q = makeQuestion('3:00');
+    expect(isTimeCorrect('300', q)).toBe(true);
+  });
+
+  it('rejects empty input', () => {
+    const q = makeQuestion('3:00');
+    expect(isTimeCorrect('', q)).toBe(false);
+    expect(isTimeCorrect('   ', q)).toBe(false);
+  });
+
+  it('rejects wrong answer', () => {
+    const q = makeQuestion('3:00');
+    expect(isTimeCorrect('4:00', q)).toBe(false);
+  });
+});
+
+describe('generateLevelQuestions', () => {
+  const wholeHourAnalog: QuestionGeneratorConfig = { type: 'wholeHours', displayMode: 'analog' };
+  const fiveMinDigital24: QuestionGeneratorConfig = { type: 'fiveMinutes', displayMode: 'digital24' };
+
+  it('returns the requested question count', () => {
+    const qs = generateLevelQuestions(wholeHourAnalog, 'freeText', 5);
+    expect(qs).toHaveLength(5);
+  });
+
+  it('generates wholeHours with minute=0', () => {
+    const qs = generateLevelQuestions(wholeHourAnalog, 'freeText', 5);
+    for (const q of qs) {
+      expect(q.minute).toBe(0);
+    }
+  });
+
+  it('generates fiveMinutes with minute divisible by 5', () => {
+    const qs = generateLevelQuestions(fiveMinDigital24, 'freeText', 10);
+    for (const q of qs) {
+      expect(q.minute % 5).toBe(0);
+    }
+  });
+
+  it('generates quarterHours with minute in [0, 15, 30, 45]', () => {
+    const qs = generateLevelQuestions({ type: 'quarterHours', displayMode: 'analog' }, 'freeText', 8);
+    for (const q of qs) {
+      expect([0, 15, 30, 45]).toContain(q.minute);
+    }
+  });
+
+  it('generates halfHours with minute in [0, 30]', () => {
+    const qs = generateLevelQuestions({ type: 'halfHours', displayMode: 'analog' }, 'freeText', 6);
+    for (const q of qs) {
+      expect([0, 30]).toContain(q.minute);
+    }
+  });
+
+  it('sets displayMode on each question', () => {
+    const qs = generateLevelQuestions(fiveMinDigital24, 'freeText', 3);
+    for (const q of qs) {
+      expect(q.displayMode).toBe('digital24');
+    }
+  });
+
+  it('defaults to analog display when none specified', () => {
+    const qs = generateLevelQuestions({ type: 'wholeHours' }, 'freeText', 3);
+    for (const q of qs) {
+      expect(q.displayMode).toBe('analog');
+    }
+  });
+
+  it('populates correctAnswer matching the display format', () => {
+    const qs = generateLevelQuestions(fiveMinDigital24, 'freeText', 3);
+    for (const q of qs) {
+      expect(q.correctAnswer).toMatch(/^\d{2}:\d{2}$/);
+    }
+  });
+
+  it('includes choices for multipleChoice mode', () => {
+    const qs = generateLevelQuestions(wholeHourAnalog, 'multipleChoice', 3);
+    for (const q of qs) {
+      expect(q.choices).toBeDefined();
+      expect(q.choices!.length).toBeGreaterThan(1);
+      expect(q.choices!.length).toBeLessThanOrEqual(4);
+      expect(q.choices).toContain(q.correctAnswer);
+    }
+  });
+
+  it('omits choices for freeText mode', () => {
+    const qs = generateLevelQuestions(wholeHourAnalog, 'freeText', 3);
+    for (const q of qs) {
+      expect(q.choices).toBeUndefined();
+    }
+  });
+
+  it('restricts hour range by period=AM', () => {
+    const qs = generateLevelQuestions(
+      { type: 'wholeHours', displayMode: 'digital24', period: 'AM' },
+      'freeText',
+      5,
+    );
+    for (const q of qs) {
+      expect(q.hour).toBeGreaterThanOrEqual(0);
+      expect(q.hour).toBeLessThanOrEqual(11);
+    }
+  });
+
+  it('restricts hour range by period=PM', () => {
+    const qs = generateLevelQuestions(
+      { type: 'wholeHours', displayMode: 'digital24', period: 'PM' },
+      'freeText',
+      5,
+    );
+    for (const q of qs) {
+      expect(q.hour).toBeGreaterThanOrEqual(12);
+      expect(q.hour).toBeLessThanOrEqual(23);
+    }
+  });
+});

--- a/clock-app/src/core/__tests__/types.test.ts
+++ b/clock-app/src/core/__tests__/types.test.ts
@@ -1,0 +1,32 @@
+import { calculateStars } from '../types';
+
+describe('calculateStars', () => {
+  it('returns 3 for a perfect score', () => {
+    expect(calculateStars(10, 10)).toBe(3);
+    expect(calculateStars(5, 5)).toBe(3);
+  });
+
+  it('returns 2 when off by one', () => {
+    expect(calculateStars(9, 10)).toBe(2);
+    expect(calculateStars(4, 5)).toBe(2);
+  });
+
+  it('returns 1 when off by two or three', () => {
+    expect(calculateStars(8, 10)).toBe(1);
+    expect(calculateStars(7, 10)).toBe(1);
+  });
+
+  it('returns 0 when off by four or more', () => {
+    expect(calculateStars(6, 10)).toBe(0);
+    expect(calculateStars(0, 10)).toBe(0);
+  });
+
+  it('handles a 5-question level: boundaries', () => {
+    expect(calculateStars(5, 5)).toBe(3);
+    expect(calculateStars(4, 5)).toBe(2);
+    expect(calculateStars(3, 5)).toBe(1);
+    expect(calculateStars(2, 5)).toBe(1);
+    expect(calculateStars(1, 5)).toBe(0);
+    expect(calculateStars(0, 5)).toBe(0);
+  });
+});

--- a/clock-app/src/lib/__tests__/format.test.ts
+++ b/clock-app/src/lib/__tests__/format.test.ts
@@ -1,0 +1,21 @@
+import { formatTime } from '../format';
+
+describe('formatTime', () => {
+  it('formats zero seconds as 0:00', () => {
+    expect(formatTime(0)).toBe('0:00');
+  });
+
+  it('pads seconds with a leading zero', () => {
+    expect(formatTime(5)).toBe('0:05');
+    expect(formatTime(65)).toBe('1:05');
+  });
+
+  it('does not pad minutes', () => {
+    expect(formatTime(59)).toBe('0:59');
+    expect(formatTime(60)).toBe('1:00');
+  });
+
+  it('handles values over an hour', () => {
+    expect(formatTime(3665)).toBe('61:05');
+  });
+});

--- a/clock-app/src/navigation/__tests__/AppNavigator.test.tsx
+++ b/clock-app/src/navigation/__tests__/AppNavigator.test.tsx
@@ -1,0 +1,43 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      upsert: jest.fn().mockResolvedValue({ error: null }),
+    })),
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+      signInAnonymously: jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-player' } },
+        error: null,
+      }),
+    },
+  },
+}));
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import AppNavigator from '../AppNavigator';
+
+describe('AppNavigator', () => {
+  it('renders WorldMap as the initial route', () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <AppNavigator />
+      </NavigationContainer>,
+    );
+    expect(getByText('Choose your adventure')).toBeTruthy();
+  });
+
+  it('renders Analog Land continent on start', () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <AppNavigator />
+      </NavigationContainer>,
+    );
+    expect(getByText('Analog Land')).toBeTruthy();
+  });
+});

--- a/clock-app/src/screens/__tests__/LevelResultScreen.test.tsx
+++ b/clock-app/src/screens/__tests__/LevelResultScreen.test.tsx
@@ -1,0 +1,93 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import LevelResultScreen from '../LevelResultScreen';
+import { useProgressStore } from '../../store/progressStore';
+import { getContinent } from '../../continents/registry';
+import { type StarRating } from '../../core/types';
+
+function makeProps(stars: StarRating, isNewBest = false) {
+  const navigate = jest.fn();
+  const replace = jest.fn();
+  const firstPath = getContinent('analogLand').paths[0];
+  return {
+    navigate,
+    replace,
+    props: {
+      navigation: { navigate, replace, goBack: jest.fn(), setParams: jest.fn() },
+      route: {
+        params: {
+          continentId: 'analogLand' as const,
+          pathId: firstPath.id,
+          levelNumber: 1,
+          score: stars === 3 ? 5 : 3,
+          total: 5,
+          stars,
+          isNewBest,
+        },
+        key: 'LevelResult',
+        name: 'LevelResult',
+      },
+    } as unknown as Parameters<typeof LevelResultScreen>[0],
+  };
+}
+
+describe('LevelResultScreen', () => {
+  beforeEach(() => {
+    useProgressStore.setState({ bestStars: {} });
+  });
+
+  it('renders the score', () => {
+    const { props } = makeProps(2);
+    const { getByText } = render(<LevelResultScreen {...props} />);
+    expect(getByText('3 / 5')).toBeTruthy();
+  });
+
+  it('renders a 3-star message', () => {
+    const { props } = makeProps(3);
+    const { getByText } = render(<LevelResultScreen {...props} />);
+    expect(getByText('Perfect score! Amazing!')).toBeTruthy();
+  });
+
+  it('renders New Best when isNewBest is true', () => {
+    const { props } = makeProps(2, true);
+    const { getByText } = render(<LevelResultScreen {...props} />);
+    expect(getByText(/New Best!/)).toBeTruthy();
+  });
+
+  it('omits New Best when isNewBest is false', () => {
+    const { props } = makeProps(2);
+    const { queryByText } = render(<LevelResultScreen {...props} />);
+    expect(queryByText(/New Best!/)).toBeNull();
+  });
+
+  it('navigates back to Path when Back to Path pressed', () => {
+    const { props, navigate } = makeProps(2);
+    const { getByText } = render(<LevelResultScreen {...props} />);
+    fireEvent.press(getByText('Back to Path'));
+    expect(navigate).toHaveBeenCalledWith('Path', expect.objectContaining({
+      continentId: 'analogLand',
+    }));
+  });
+
+  it('replaces to the same level when Try Again pressed', () => {
+    const { props, replace } = makeProps(1);
+    const { getByText } = render(<LevelResultScreen {...props} />);
+    fireEvent.press(getByText('Try Again'));
+    expect(replace).toHaveBeenCalledWith('Level', expect.objectContaining({
+      levelNumber: 1,
+    }));
+  });
+
+  it('shows Next Level when there is a next level and score > 0', () => {
+    const { props, replace } = makeProps(2);
+    const { getByText } = render(<LevelResultScreen {...props} />);
+    fireEvent.press(getByText('Next Level'));
+    expect(replace).toHaveBeenCalledWith('Level', expect.objectContaining({
+      levelNumber: 2,
+    }));
+  });
+});

--- a/clock-app/src/screens/__tests__/LevelScreen.test.tsx
+++ b/clock-app/src/screens/__tests__/LevelScreen.test.tsx
@@ -1,0 +1,67 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+jest.mock('../../lib/haptics', () => ({
+  hapticCorrect: jest.fn(),
+  hapticWrong: jest.fn(),
+  hapticSuccess: jest.fn(),
+  hapticSelection: jest.fn(),
+}));
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import LevelScreen from '../LevelScreen';
+import { useProgressStore } from '../../store/progressStore';
+import { getContinent } from '../../continents/registry';
+
+function makeProps(levelNumber: number) {
+  const navigate = jest.fn();
+  const goBack = jest.fn();
+  const replace = jest.fn();
+  const firstPath = getContinent('analogLand').paths[0];
+  return {
+    navigate,
+    goBack,
+    replace,
+    props: {
+      navigation: { navigate, goBack, replace, setParams: jest.fn() },
+      route: {
+        params: { continentId: 'analogLand' as const, pathId: firstPath.id, levelNumber },
+        key: 'Level',
+        name: 'Level',
+      },
+    } as unknown as Parameters<typeof LevelScreen>[0],
+  };
+}
+
+describe('LevelScreen', () => {
+  beforeEach(() => {
+    useProgressStore.setState({ bestStars: {} });
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    act(() => { jest.runOnlyPendingTimers(); });
+    jest.useRealTimers();
+  });
+
+  it('renders the level title in the header', () => {
+    const { props } = makeProps(1);
+    const path = getContinent('analogLand').paths[0];
+    const { getByText } = render(<LevelScreen {...props} />);
+    expect(getByText(`${path.title} — Level 1`)).toBeTruthy();
+  });
+
+  it('renders a quit button', () => {
+    const { props, goBack } = makeProps(1);
+    const { getByText } = render(<LevelScreen {...props} />);
+    fireEvent.press(getByText(/Quit/));
+    expect(goBack).toHaveBeenCalled();
+  });
+
+  it('returns null when the level is outside of the static + bonus range', () => {
+    const { props } = makeProps(0);
+    const { toJSON } = render(<LevelScreen {...props} />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/clock-app/src/screens/__tests__/PathScreen.test.tsx
+++ b/clock-app/src/screens/__tests__/PathScreen.test.tsx
@@ -1,0 +1,91 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import PathScreen from '../PathScreen';
+import { useProgressStore } from '../../store/progressStore';
+import { getContinent } from '../../continents/registry';
+
+function makeProps(pathId: string) {
+  const navigate = jest.fn();
+  const goBack = jest.fn();
+  return {
+    navigate,
+    goBack,
+    props: {
+      navigation: { navigate, goBack, setParams: jest.fn(), replace: jest.fn() },
+      route: {
+        params: { continentId: 'analogLand' as const, pathId },
+        key: 'Path',
+        name: 'Path',
+      },
+    } as unknown as Parameters<typeof PathScreen>[0],
+  };
+}
+
+describe('PathScreen', () => {
+  beforeEach(() => {
+    useProgressStore.setState({ bestStars: {} });
+  });
+
+  const firstPathId = getContinent('analogLand').paths[0].id;
+  const path = getContinent('analogLand').paths[0];
+
+  it('renders the path title and description', () => {
+    const { props } = makeProps(firstPathId);
+    const { getAllByText, getByText } = render(<PathScreen {...props} />);
+    // Title appears in the header and the path chip.
+    expect(getAllByText(path.title).length).toBeGreaterThan(0);
+    expect(getByText(path.description)).toBeTruthy();
+  });
+
+  it('renders a LevelCard for each static level', () => {
+    const { props } = makeProps(firstPathId);
+    const { getAllByText } = render(<PathScreen {...props} />);
+    for (const level of path.levels) {
+      expect(getAllByText(`Level ${level.levelNumber}`).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('navigates to Level when a level card is pressed', () => {
+    const { props, navigate } = makeProps(firstPathId);
+    const { getAllByText } = render(<PathScreen {...props} />);
+    fireEvent.press(getAllByText(`Level ${path.levels[0].levelNumber}`)[0]);
+    expect(navigate).toHaveBeenCalledWith(
+      'Level',
+      expect.objectContaining({
+        continentId: 'analogLand',
+        pathId: firstPathId,
+        levelNumber: path.levels[0].levelNumber,
+      }),
+    );
+  });
+
+  it('shows locked boss message until path is complete', () => {
+    const { props } = makeProps(firstPathId);
+    const { getByText } = render(<PathScreen {...props} />);
+    expect(getByText(/Get 3 stars on every level/)).toBeTruthy();
+  });
+
+  it('shows bonus levels once path is complete', () => {
+    const state: Record<string, 3> = {};
+    for (const l of path.levels) {
+      state[`analogLand:${firstPathId}:${l.levelNumber}`] = 3;
+    }
+    useProgressStore.setState({ bestStars: state });
+
+    const { props } = makeProps(firstPathId);
+    const { getByText } = render(<PathScreen {...props} />);
+    expect(getByText(/Bonus Levels/)).toBeTruthy();
+    expect(getByText(/Boss Collected/)).toBeTruthy();
+  });
+
+  it('goes back when Back to Map pressed', () => {
+    const { props, goBack } = makeProps(firstPathId);
+    const { getByText } = render(<PathScreen {...props} />);
+    fireEvent.press(getByText(/Back to Map/));
+    expect(goBack).toHaveBeenCalled();
+  });
+});

--- a/clock-app/src/screens/__tests__/WorldMapScreen.test.tsx
+++ b/clock-app/src/screens/__tests__/WorldMapScreen.test.tsx
@@ -1,0 +1,82 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import WorldMapScreen from '../WorldMapScreen';
+import { useProgressStore } from '../../store/progressStore';
+import { getContinent } from '../../continents/registry';
+
+function makeProps() {
+  const navigate = jest.fn();
+  return {
+    navigate,
+    props: {
+      navigation: {
+        navigate,
+        goBack: jest.fn(),
+        setParams: jest.fn(),
+        replace: jest.fn(),
+      },
+      route: { params: undefined, key: 'WorldMap', name: 'WorldMap' },
+    } as unknown as Parameters<typeof WorldMapScreen>[0],
+  };
+}
+
+describe('WorldMapScreen', () => {
+  beforeEach(() => {
+    useProgressStore.setState({ bestStars: {} });
+  });
+
+  it('renders the header', () => {
+    const { props } = makeProps();
+    const { getByText } = render(<WorldMapScreen {...props} />);
+    expect(getByText(/Clock Quest/)).toBeTruthy();
+    expect(getByText('Choose your adventure')).toBeTruthy();
+  });
+
+  it('renders every continent by title', () => {
+    const { props } = makeProps();
+    const { getByText } = render(<WorldMapScreen {...props} />);
+    expect(getByText('Analog Land')).toBeTruthy();
+    // digital24 / digital12 start locked but still render their titles
+    expect(getByText(getContinent('digital24').title)).toBeTruthy();
+    expect(getByText(getContinent('digital12').title)).toBeTruthy();
+  });
+
+  it('locks non-prerequisite continents initially', () => {
+    const { props } = makeProps();
+    const { getAllByText } = render(<WorldMapScreen {...props} />);
+    // Both digital24 and digital12 start locked.
+    expect(getAllByText(/Complete the previous continent/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('navigates to Path when an unlocked continent is pressed', () => {
+    const { props, navigate } = makeProps();
+    const { getByText } = render(<WorldMapScreen {...props} />);
+    fireEvent.press(getByText('Analog Land'));
+    expect(navigate).toHaveBeenCalledWith('Path', expect.objectContaining({
+      continentId: 'analogLand',
+    }));
+  });
+
+  it('unlocks the next continent once the prerequisite is complete', () => {
+    const analog = getContinent('analogLand');
+    const state: Record<string, 3> = {};
+    for (const p of analog.paths) {
+      for (const l of p.levels) {
+        state[`analogLand:${p.id}:${l.levelNumber}`] = 3;
+      }
+    }
+    useProgressStore.setState({ bestStars: state });
+
+    const { props } = makeProps();
+    const { queryByText } = render(<WorldMapScreen {...props} />);
+    // digital24 should now be unlocked; digital12 should still be locked
+    // Both share the same "Complete the previous continent" copy when locked.
+    // With one prerequisite complete we expect only one locked continent left.
+    const locks = queryByText(/Complete the previous continent/);
+    expect(locks).toBeTruthy();
+  });
+});

--- a/clock-app/src/services/__tests__/playerService.test.ts
+++ b/clock-app/src/services/__tests__/playerService.test.ts
@@ -1,0 +1,76 @@
+const mockUpsert = jest.fn();
+const mockSelect = jest.fn();
+const mockIlike = jest.fn();
+const mockLimit = jest.fn();
+
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      upsert: mockUpsert,
+      select: mockSelect,
+    })),
+  },
+}));
+
+import { upsertPlayer, searchPlayersByNickname } from '../playerService';
+import { supabase } from '../../lib/supabase';
+
+const mockedFrom = supabase.from as jest.MockedFunction<typeof supabase.from>;
+
+describe('upsertPlayer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpsert.mockResolvedValue({ error: null });
+  });
+
+  it('targets the players table', async () => {
+    await upsertPlayer('abc', 'Tester');
+    expect(mockedFrom).toHaveBeenCalledWith('players');
+  });
+
+  it('passes id/nickname and conflict key', async () => {
+    await upsertPlayer('abc', 'Tester');
+    expect(mockUpsert).toHaveBeenCalledWith({ id: 'abc', nickname: 'Tester' }, { onConflict: 'id' });
+  });
+
+  it('resolves even on supabase error', async () => {
+    mockUpsert.mockResolvedValue({ error: { message: 'boom' } });
+    await expect(upsertPlayer('abc', 'Tester')).resolves.toBeUndefined();
+  });
+});
+
+describe('searchPlayersByNickname', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelect.mockReturnValue({ ilike: mockIlike });
+    mockIlike.mockReturnValue({ limit: mockLimit });
+  });
+
+  it('queries players table with ilike wildcard and limit 10', async () => {
+    mockLimit.mockResolvedValue({ data: [], error: null });
+    await searchPlayersByNickname('Test');
+    expect(mockedFrom).toHaveBeenCalledWith('players');
+    expect(mockSelect).toHaveBeenCalledWith('id, nickname');
+    expect(mockIlike).toHaveBeenCalledWith('nickname', '%Test%');
+    expect(mockLimit).toHaveBeenCalledWith(10);
+  });
+
+  it('returns the rows on success', async () => {
+    const rows = [{ id: 'a', nickname: 'Amy' }];
+    mockLimit.mockResolvedValue({ data: rows, error: null });
+    const result = await searchPlayersByNickname('Amy');
+    expect(result).toEqual(rows);
+  });
+
+  it('returns empty array on error', async () => {
+    mockLimit.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    const result = await searchPlayersByNickname('Amy');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when data is null and no error', async () => {
+    mockLimit.mockResolvedValue({ data: null, error: null });
+    const result = await searchPlayersByNickname('Amy');
+    expect(result).toEqual([]);
+  });
+});

--- a/clock-app/src/services/__tests__/scoreService.test.ts
+++ b/clock-app/src/services/__tests__/scoreService.test.ts
@@ -1,0 +1,63 @@
+const mockInsert = jest.fn();
+const mockSelect = jest.fn();
+const mockSingle = jest.fn();
+
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({ insert: mockInsert })),
+  },
+}));
+
+import { submitScore } from '../scoreService';
+import { supabase } from '../../lib/supabase';
+
+const mockedFrom = supabase.from as jest.MockedFunction<typeof supabase.from>;
+
+describe('submitScore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ single: mockSingle });
+  });
+
+  const params = {
+    playerId: 'p1',
+    gameId: 'clock',
+    score: 8,
+    total: 10,
+    duration: 42,
+  };
+
+  it('targets the scores table', async () => {
+    mockSingle.mockResolvedValue({ data: { id: 'score-1' }, error: null });
+    await submitScore(params);
+    expect(mockedFrom).toHaveBeenCalledWith('scores');
+  });
+
+  it('sends the expected payload shape', async () => {
+    mockSingle.mockResolvedValue({ data: { id: 'score-1' }, error: null });
+    await submitScore(params);
+    expect(mockInsert).toHaveBeenCalledWith({
+      player_id: 'p1',
+      game_id: 'clock',
+      score: 8,
+      total: 10,
+      duration: 42,
+    });
+  });
+
+  it('returns the inserted id on success', async () => {
+    mockSingle.mockResolvedValue({ data: { id: 'score-1' }, error: null });
+    await expect(submitScore(params)).resolves.toBe('score-1');
+  });
+
+  it('returns null on supabase error', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(submitScore(params)).resolves.toBeNull();
+  });
+
+  it('returns null when no row is returned', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: null });
+    await expect(submitScore(params)).resolves.toBeNull();
+  });
+});

--- a/clock-app/src/store/__tests__/authStore.test.ts
+++ b/clock-app/src/store/__tests__/authStore.test.ts
@@ -1,0 +1,67 @@
+const mockGetSession = jest.fn();
+const mockSignInAnonymously = jest.fn();
+
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      get getSession() { return mockGetSession; },
+      get signInAnonymously() { return mockSignInAnonymously; },
+    },
+  },
+}));
+
+import { useAuthStore } from '../authStore';
+
+describe('authStore', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ playerId: null, isReady: false });
+    jest.clearAllMocks();
+  });
+
+  it('starts with null playerId and not ready', () => {
+    const state = useAuthStore.getState();
+    expect(state.playerId).toBeNull();
+    expect(state.isReady).toBe(false);
+  });
+
+  it('uses existing session if available', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: { id: 'existing-user-123' } } },
+    });
+
+    await useAuthStore.getState().init();
+
+    const state = useAuthStore.getState();
+    expect(state.playerId).toBe('existing-user-123');
+    expect(state.isReady).toBe(true);
+    expect(mockSignInAnonymously).not.toHaveBeenCalled();
+  });
+
+  it('signs in anonymously when no session exists', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+    mockSignInAnonymously.mockResolvedValue({
+      data: { user: { id: 'anon-user-456' } },
+      error: null,
+    });
+
+    await useAuthStore.getState().init();
+
+    const state = useAuthStore.getState();
+    expect(state.playerId).toBe('anon-user-456');
+    expect(state.isReady).toBe(true);
+  });
+
+  it('handles sign-in failure gracefully', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+    mockSignInAnonymously.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Network error' },
+    });
+
+    await useAuthStore.getState().init();
+
+    const state = useAuthStore.getState();
+    expect(state.playerId).toBeNull();
+    expect(state.isReady).toBe(true);
+  });
+});

--- a/clock-app/src/store/__tests__/playerStore.test.ts
+++ b/clock-app/src/store/__tests__/playerStore.test.ts
@@ -1,0 +1,63 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      upsert: jest.fn().mockResolvedValue({ error: null }),
+    })),
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+      signInAnonymously: jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-id' } },
+        error: null,
+      }),
+    },
+  },
+}));
+
+jest.mock('../../services/playerService', () => ({
+  upsertPlayer: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { usePlayerStore } from '../playerStore';
+import { useAuthStore } from '../authStore';
+import { upsertPlayer } from '../../services/playerService';
+
+const mockedUpsert = upsertPlayer as jest.MockedFunction<typeof upsertPlayer>;
+
+describe('playerStore', () => {
+  beforeEach(() => {
+    usePlayerStore.setState({ nickname: null });
+    useAuthStore.setState({ playerId: null, isReady: false });
+    jest.clearAllMocks();
+  });
+
+  it('starts with null nickname', () => {
+    expect(usePlayerStore.getState().nickname).toBeNull();
+  });
+
+  it('sets nickname and trims whitespace', () => {
+    usePlayerStore.getState().setNickname('  Tester  ');
+    expect(usePlayerStore.getState().nickname).toBe('Tester');
+  });
+
+  it('upserts to Supabase when playerId is set', () => {
+    useAuthStore.setState({ playerId: 'player-1', isReady: true });
+    usePlayerStore.getState().setNickname('Tester');
+    expect(mockedUpsert).toHaveBeenCalledWith('player-1', 'Tester');
+  });
+
+  it('does not call upsert when no playerId', () => {
+    usePlayerStore.getState().setNickname('Tester');
+    expect(mockedUpsert).not.toHaveBeenCalled();
+  });
+
+  it('does not call upsert when nickname is empty after trim', () => {
+    useAuthStore.setState({ playerId: 'player-1', isReady: true });
+    usePlayerStore.getState().setNickname('   ');
+    expect(mockedUpsert).not.toHaveBeenCalled();
+    expect(usePlayerStore.getState().nickname).toBe('');
+  });
+});

--- a/clock-app/src/store/__tests__/progressStore.test.ts
+++ b/clock-app/src/store/__tests__/progressStore.test.ts
@@ -1,0 +1,66 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+import { useProgressStore } from '../progressStore';
+import { getContinent } from '../../continents/registry';
+
+describe('progressStore', () => {
+  beforeEach(() => {
+    useProgressStore.setState({ bestStars: {} });
+  });
+
+  it('returns 0 stars for unplayed levels', () => {
+    expect(useProgressStore.getState().getBestStars('analogLand', 'unknown', 1)).toBe(0);
+  });
+
+  it('records stars and persists the best-so-far', () => {
+    useProgressStore.getState().recordStars('analogLand', 'p', 1, 2);
+    expect(useProgressStore.getState().getBestStars('analogLand', 'p', 1)).toBe(2);
+  });
+
+  it('does not overwrite a higher score with a lower one', () => {
+    useProgressStore.getState().recordStars('analogLand', 'p', 1, 3);
+    useProgressStore.getState().recordStars('analogLand', 'p', 1, 1);
+    expect(useProgressStore.getState().getBestStars('analogLand', 'p', 1)).toBe(3);
+  });
+
+  it('keys bestStars independently per level/path/continent', () => {
+    useProgressStore.getState().recordStars('analogLand', 'p1', 1, 2);
+    useProgressStore.getState().recordStars('analogLand', 'p2', 1, 3);
+    expect(useProgressStore.getState().getBestStars('analogLand', 'p1', 1)).toBe(2);
+    expect(useProgressStore.getState().getBestStars('analogLand', 'p2', 1)).toBe(3);
+  });
+
+  it('isPathComplete returns false until every level has 3 stars', () => {
+    const continent = getContinent('analogLand');
+    const path = continent.paths[0];
+    expect(useProgressStore.getState().isPathComplete('analogLand', path.id)).toBe(false);
+
+    for (const level of path.levels) {
+      useProgressStore.getState().recordStars('analogLand', path.id, level.levelNumber, 2);
+    }
+    expect(useProgressStore.getState().isPathComplete('analogLand', path.id)).toBe(false);
+
+    for (const level of path.levels) {
+      useProgressStore.getState().recordStars('analogLand', path.id, level.levelNumber, 3);
+    }
+    expect(useProgressStore.getState().isPathComplete('analogLand', path.id)).toBe(true);
+  });
+
+  it('isPathComplete returns false for an unknown path', () => {
+    expect(useProgressStore.getState().isPathComplete('analogLand', 'nope')).toBe(false);
+  });
+
+  it('isContinentComplete requires every level on every path to be 3-star', () => {
+    const continent = getContinent('analogLand');
+    expect(useProgressStore.getState().isContinentComplete('analogLand')).toBe(false);
+
+    for (const path of continent.paths) {
+      for (const level of path.levels) {
+        useProgressStore.getState().recordStars('analogLand', path.id, level.levelNumber, 3);
+      }
+    }
+    expect(useProgressStore.getState().isContinentComplete('analogLand')).toBe(true);
+  });
+});

--- a/clock-app/src/theme/__tests__/ThemeContext.test.tsx
+++ b/clock-app/src/theme/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ThemeProvider, useTheme, defaultTheme } from '../ThemeContext';
+import { type Theme } from '../../core/types';
+
+function Probe({ next }: Readonly<{ next?: Theme }>) {
+  const { theme, setTheme } = useTheme();
+  return (
+    <>
+      <Text testID="primary">{theme.primary}</Text>
+      <Text testID="accent">{theme.accent}</Text>
+      {next && (
+        <TouchableOpacity testID="set" onPress={() => setTheme(next)}>
+          <Text>set</Text>
+        </TouchableOpacity>
+      )}
+    </>
+  );
+}
+
+describe('ThemeContext', () => {
+  it('exposes the default theme', () => {
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(getByTestId('primary').props.children).toBe(defaultTheme.primary);
+    expect(getByTestId('accent').props.children).toBe(defaultTheme.accent);
+  });
+
+  it('updates when setTheme is called', () => {
+    const next: Theme = {
+      ...defaultTheme,
+      primary: '#ff0000',
+      accent: '#00ff00',
+    };
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <Probe next={next} />
+      </ThemeProvider>,
+    );
+
+    fireEvent.press(getByTestId('set'));
+
+    expect(getByTestId('primary').props.children).toBe('#ff0000');
+    expect(getByTestId('accent').props.children).toBe('#00ff00');
+  });
+
+  it('useTheme outside provider falls back to default', () => {
+    const { getByTestId } = render(<Probe />);
+    expect(getByTestId('primary').props.children).toBe(defaultTheme.primary);
+  });
+
+  it('defaultTheme has all required fields', () => {
+    expect(defaultTheme).toEqual(
+      expect.objectContaining({
+        primary: expect.any(String),
+        secondary: expect.any(String),
+        secondaryRgb: expect.any(String),
+        accent: expect.any(String),
+        splashBg: expect.any(String),
+        gradientBg: expect.any(Array),
+        gradientCard: expect.any(Array),
+        gradientAccent: expect.any(Array),
+        glowColor: expect.any(String),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 25 Jest test files / 158 tests for the clock-app, mirroring the coverage pattern in mobile-app/
- Covers core logic (clockLogic, bonusGenerator, types, LevelEngine), stores (auth, player, progress), services (player, score), components (AnalogClock, DigitalClock, FeedbackBanner, LevelCard, MultipleChoice, ProgressDots, StarDisplay, TimeInput), screens (WorldMap, Path, Level, LevelResult), theme (ThemeContext), registry, navigation (AppNavigator), and lib (format)
- Uses jest-expo preset + @testing-library/react-native; Zustand stores reset in beforeEach; Supabase and AsyncStorage mocked per test

Stacked on top of #64 (bjorkman/clock-splash).

## Test plan
- [x] \`yarn test\` — 25 suites, 158 tests passing
- [x] \`yarn lint\` — 0 errors (4 pre-existing warnings unrelated to tests)